### PR TITLE
Target NET 5 for Azure support

### DIFF
--- a/BrowserVersions.API/BrowserVersions.API.csproj
+++ b/BrowserVersions.API/BrowserVersions.API.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFrameworks>net5.0;net6.0</TargetFrameworks>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Azure App Services do not support NET 6 as of now (or I'm too stupid to configure it) so dual target for the deploy only for now